### PR TITLE
chore: debug empty `projectKeyInput` strings

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -43796,7 +43796,7 @@ async function run() {
     const projectKeyInput = coreExports.getInput("project-key");
     const directory = coreExports.getInput("directory");
     const hubUrl = coreExports.getInput("hub-url");
-    if (projectKeyInput) coreExports.debug(`Linked with: ${projectKeyInput}`);
+    if (projectKeyInput !== void 0) coreExports.debug(`Linked with: \`${projectKeyInput}\``);
     coreExports.debug(`Nuxt output directory: ${directory}`);
     coreExports.debug(`NuxtHub URL: ${hubUrl}`);
     let accessToken = "";

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ export async function run() {
     const directory = core.getInput('directory')
     const hubUrl = core.getInput('hub-url')
 
-    if (projectKeyInput) core.debug(`Linked with: ${projectKeyInput}`)
+    if (projectKeyInput !== undefined) core.debug(`Linked with: \`${projectKeyInput}\``)
     core.debug(`Nuxt output directory: ${directory}`)
     core.debug(`NuxtHub URL: ${hubUrl}`)
 


### PR DESCRIPTION
While debugging my deployment script, it took me a few minutes to realize that I got an empty string. Hope this tiny change can help in the future for other people.

Also, I have added back-tick to let the user know that is empty string:

`Linked with: `` ` VS `Linked with: ` 

